### PR TITLE
Use forked `move-lang` repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,7 +53,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cipher",
  "cpufeatures",
  "opaque-debug",
@@ -1736,7 +1736,7 @@ dependencies = [
  "async-io",
  "autocfg",
  "blocking",
- "cfg-if 1.0.0",
+ "cfg-if",
  "event-listener",
  "futures-lite",
  "libc",
@@ -1884,7 +1884,7 @@ checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -2196,7 +2196,7 @@ checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 [[package]]
 name = "bytecode-interpreter-crypto"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "curve25519-dalek-fiat",
@@ -2299,12 +2299,6 @@ checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
 dependencies = [
  "nom 7.1.1",
 ]
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -2458,15 +2452,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -2789,7 +2774,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -2844,7 +2829,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2801af0d36612ae591caa9568261fddce32ce6e08a7275ea334a06a4ad021a2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-epoch",
@@ -2858,7 +2843,7 @@ version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -2868,7 +2853,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -2880,7 +2865,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset",
  "once_cell",
@@ -2893,7 +2878,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1cd42583b04998a5363558e5f9291ee5a5ff6b49944332103f251e7479a82aa7"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -2903,7 +2888,7 @@ version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "once_cell",
 ]
 
@@ -3133,7 +3118,7 @@ version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "num_cpus",
  "parking_lot 0.12.1",
 ]
@@ -3325,7 +3310,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "dirs-sys-next",
 ]
 
@@ -3454,7 +3439,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -4141,7 +4126,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -4152,7 +4137,7 @@ version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -4740,7 +4725,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -5067,7 +5052,7 @@ checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
 dependencies = [
  "arrayvec",
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "ryu",
  "static_assertions",
 ]
@@ -5106,7 +5091,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi 0.3.9",
 ]
 
@@ -5228,15 +5213,6 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
@@ -5250,7 +5226,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "serde 1.0.144",
  "value-bag",
 ]
@@ -5463,7 +5439,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2be9a9090bc1cac2930688fa9478092a64c6a92ddc6ae0692d46b37d9cab709"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "downcast",
  "fragile",
  "lazy_static 1.4.0",
@@ -5478,7 +5454,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86d702a0530a0141cf4ed147cf5ec7be6f2c187d4e37fcbefc39cf34116bfe8f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
  "syn 1.0.99",
@@ -5493,7 +5469,7 @@ checksum = "5474f8732dc7e0635ae9df6595bcd39cd30e3cfe8479850d4fa3e69306c19712"
 [[package]]
 name = "move-abigen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5510,7 +5486,7 @@ dependencies = [
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-core-types",
@@ -5525,12 +5501,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5545,7 +5521,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5557,7 +5533,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5569,7 +5545,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5586,7 +5562,7 @@ dependencies = [
 [[package]]
 name = "move-cli"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5632,7 +5608,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "difference",
@@ -5649,7 +5625,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5678,7 +5654,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5695,7 +5671,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5749,7 +5725,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -5767,7 +5743,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5785,7 +5761,7 @@ dependencies = [
 [[package]]
 name = "move-errmapgen"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5811,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "move-ir-compiler"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5830,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5849,7 +5825,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "hex",
@@ -5862,7 +5838,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "hex",
@@ -5876,7 +5852,7 @@ dependencies = [
 [[package]]
 name = "move-model"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "codespan",
@@ -5902,7 +5878,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5938,7 +5914,7 @@ dependencies = [
 [[package]]
 name = "move-prover"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5975,7 +5951,7 @@ dependencies = [
 [[package]]
 name = "move-prover-boogie-backend"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6003,7 +5979,7 @@ dependencies = [
 [[package]]
 name = "move-prover-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-command-line-common",
@@ -6014,7 +5990,7 @@ dependencies = [
 [[package]]
 name = "move-read-write-set-types"
 version = "0.0.3"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6025,7 +6001,7 @@ dependencies = [
 [[package]]
 name = "move-resource-viewer"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6040,7 +6016,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "codespan",
  "codespan-reporting",
@@ -6067,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "move-stackless-bytecode-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bytecode-interpreter-crypto",
@@ -6085,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib"
 version = "0.1.1"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "log",
@@ -6107,7 +6083,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "once_cell",
  "serde 1.0.144",
@@ -6116,7 +6092,7 @@ dependencies = [
 [[package]]
 name = "move-table-extension"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -6133,7 +6109,7 @@ dependencies = [
 [[package]]
 name = "move-transactional-test-runner"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "clap 3.2.17",
@@ -6164,7 +6140,7 @@ dependencies = [
 [[package]]
 name = "move-unit-test"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "better_any",
@@ -6195,7 +6171,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "better_any",
  "fail 0.4.0",
@@ -6212,7 +6188,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -6226,7 +6202,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6291,13 +6267,13 @@ dependencies = [
 
 [[package]]
 name = "named-lock"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3ab176d4bcfbcb53b8c7c5a25cb2c01674cda33db27064a85a16814c88c1f2d"
+checksum = "40a3eb6b7c682b65d1f631ec3176829d72ab450b3aacdd3f719bf220822e59ac"
 dependencies = [
  "libc",
  "once_cell",
- "parking_lot 0.10.2",
+ "parking_lot 0.12.1",
  "thiserror",
  "widestring",
  "winapi 0.3.9",
@@ -6663,7 +6639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -6756,22 +6732,12 @@ checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
 name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.2",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.6",
+ "lock_api",
  "parking_lot_core 0.8.5",
 ]
 
@@ -6781,22 +6747,8 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
- "lock_api 0.4.6",
+ "lock_api",
  "parking_lot_core 0.9.3",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -6805,7 +6757,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "instant",
  "libc",
  "redox_syscall 0.2.16",
@@ -6819,7 +6771,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall 0.2.16",
  "smallvec",
@@ -7212,7 +7164,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899b00b9c8ab553c743b3e11e87c5c7d423b2a2de229ba95b24a756344748011"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "log",
  "wepoll-ffi",
@@ -7225,7 +7177,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8419d2b623c7c0896ff2d5d96e2cb4ede590fed28fcc34934f4c33c036e620a1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "opaque-debug",
  "universal-hash",
@@ -7400,7 +7352,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cface98dfa6d645ea4c789839f176e4b072265d085bfcc48eaa8d137f58d3c39"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fnv",
  "lazy_static 1.4.0",
  "memchr",
@@ -7776,7 +7728,7 @@ dependencies = [
 [[package]]
 name = "read-write-set"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -7791,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "read-write-set-dynamic"
 version = "0.1.0"
-source = "git+https://github.com/move-language/move?rev=59265662d0a44ba53b09ba3c4b2248efdf08c622#59265662d0a44ba53b09ba3c4b2248efdf08c622"
+source = "git+https://github.com/bobchainer/move?branch=call-traces#a62c2223fe97534a2f2a519e2d36220bf30860a5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -8037,7 +7989,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5015e68a0685a95ade3eee617ff7101ab6a3fc689203101ca16ebc16f2b89c66"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "proc-macro2 1.0.43",
  "quote 1.0.21",
  "rustc_version",
@@ -8531,7 +8483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99cd6713db3cf16b6c84e06321e049a9b9f699826e16096d23bbcc44d15d51a6"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -8543,7 +8495,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -8555,7 +8507,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -8567,7 +8519,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest 0.10.3",
 ]
@@ -9121,7 +9073,7 @@ version = "0.24.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54cb4ebf3d49308b99e6e9dc95e989e2fdbdc210e4f67c39db0bb89ba927001c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "core-foundation-sys",
  "libc",
  "ntapi",
@@ -9151,7 +9103,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "libc",
  "redox_syscall 0.2.16",
@@ -9684,7 +9636,7 @@ version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -10306,7 +10258,7 @@ version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -10331,7 +10283,7 @@ version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -10452,9 +10404,9 @@ dependencies = [
 
 [[package]]
 name = "widestring"
-version = "0.4.3"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
+checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,3 +184,34 @@ debug = true
 rocksdb = { git = 'https://github.com/aptos-labs/rust-rocksdb' }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "839aed62a20ddccf043c08961cfe74875741ccba" }
 diesel = { git = "https://github.com/aptos-labs/diesel", branch = "1.4.x" }
+
+# Replacing original dependences of "move-language/move"
+[patch."https://github.com/move-language/move"]
+move-abigen = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-binary-format = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-bytecode-utils = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-bytecode-verifier = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-cli = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-command-line-common = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-compiler = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-core-types = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-docgen = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-errmapgen = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-ir-compiler = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-model = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-package = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-prover = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-prover-boogie-backend = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-prover-test-utils = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-resource-viewer = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-stdlib = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-symbol-pool = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-table-extension = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-transactional-test-runner = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-unit-test = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-vm-runtime = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-vm-test-utils = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+move-vm-types = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+read-write-set = { git = "https://github.com/bobchainer/move", branch = "call-traces" }
+read-write-set-dynamic = { git = "https://github.com/bobchainer/move", branch = "call-traces" }

--- a/aptos-move/aptos-gas/src/gas_meter.rs
+++ b/aptos-move/aptos-gas/src/gas_meter.rs
@@ -149,6 +149,7 @@ impl InitialGasSchedule for AptosGasParameters {
 pub struct AptosGasMeter {
     gas_params: AptosGasParameters,
     balance: InternalGas,
+    initial_balance: InternalGas,
 }
 
 impl AptosGasMeter {
@@ -156,6 +157,7 @@ impl AptosGasMeter {
         let balance = balance.into().to_unit_with_params(&gas_params.txn);
 
         Self {
+            initial_balance: balance.clone(),
             gas_params,
             balance,
         }
@@ -466,6 +468,13 @@ impl GasMeter for AptosGasMeter {
     #[inline]
     fn charge_vec_swap(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
         self.charge(self.gas_params.instr.vec_swap_base)
+    }
+
+    #[inline]
+    fn charged_already_total(&self) -> PartialVMResult<InternalGas> {
+        let used_gas = self.initial_balance.checked_sub(self.balance).unwrap();
+
+        Ok(used_gas)
     }
 }
 

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -62,6 +62,7 @@ use std::{
     sync::Arc,
 };
 use vm_genesis::GENESIS_KEYPAIR;
+
 /**
  * Definitions
  */
@@ -758,6 +759,7 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
         let a = SerializedReturnValues {
             mutable_reference_outputs: vec![(0, vec![0], MoveTypeLayout::U8)],
             return_values: vec![(vec![0], MoveTypeLayout::U8)],
+            call_traces: vec![],
         };
 
         Ok((output, a))
@@ -849,6 +851,7 @@ impl<'a> MoveTestAdapter<'a> for AptosTestAdapter<'a> {
         let a = SerializedReturnValues {
             mutable_reference_outputs: vec![(0, vec![0], MoveTypeLayout::U8)],
             return_values: vec![(vec![0], MoveTypeLayout::U8)],
+            call_traces: vec![],
         };
         Ok((output, a))
     }


### PR DESCRIPTION
I've used `patch` instead of manually editing each `Cargo.toml` to avoid potential merge conflicts in future updates.

Those commands pass:
- `cargo test --no-fail-fast -- --test-threads=1`
- `cargo check --workspace`
- `cargo check -p aptos-node --all-features`

`Cargo.lock` doesn't contain references to `move-language/move` anymore.

Issues (doesn't seem to be related with our changes):
- Some tests fail due to concurrency error if `test-threads > 1`
- `cargo check --workspace --all-features` fails due to macro error in `aptos-crypto` crate
