### PR TITLE
Fix config file format for `backup-validate` and `restore` jobs

### DIFF
--- a/terraform/helm/fullnode/templates/backup-verify.yaml
+++ b/terraform/helm/fullnode/templates/backup-verify.yaml
@@ -37,7 +37,7 @@ spec:
             - command-adapter
             - --config
             # use the same config with the backup sts
-            - /opt/aptos/etc/{{ .Values.backup.config.location }}.toml
+            - /opt/aptos/etc/{{ .Values.backup.config.location }}.yaml
             env:
             - name: RUST_LOG
               value: "debug"

--- a/terraform/helm/fullnode/templates/restore.yaml
+++ b/terraform/helm/fullnode/templates/restore.yaml
@@ -35,7 +35,7 @@ spec:
               echo "$CONTROLLER_UID" > /opt/aptos/data/restore-uid
           fi
           # start restore process
-          /usr/local/bin/db-restore --concurrent-downloads {{ .config.concurrent_downloads }}{{ range .config.trusted_waypoints }} --trust-waypoint {{ . }}{{ end }} --target-db-dir /opt/aptos/data/db auto --metadata-cache-dir /tmp/aptos-restore-metadata command-adapter --config /opt/aptos/etc/{{ .config.location }}.toml
+          /usr/local/bin/db-restore --concurrent-downloads {{ .config.concurrent_downloads }}{{ range .config.trusted_waypoints }} --trust-waypoint {{ . }}{{ end }} --target-db-dir /opt/aptos/data/db auto --metadata-cache-dir /tmp/aptos-restore-metadata command-adapter --config /opt/aptos/etc/{{ .config.location }}.yaml
         env:
         - name: RUST_LOG
           value: "debug"


### PR DESCRIPTION
The actual config format is `yaml`